### PR TITLE
feat: add authenticated upload API route

### DIFF
--- a/actions/convert-document.ts
+++ b/actions/convert-document.ts
@@ -1,16 +1,10 @@
 "use server";
 
-import { getDocumentProcessor } from "@/lib/document-processor";
-import { generateStorageKey } from "@/lib/document-processor/utils/storage";
-import { env } from "@/lib/env";
-import { generateAndCacheAllGlossaries } from "@/lib/translation/glossary";
-import { createXai } from "@ai-sdk/xai";
-import { revalidatePath } from "next/cache";
+import { processUploadedFile } from "@/lib/upload";
 import { redirect } from "next/navigation";
-import { after } from "next/server";
 
 /**
- * 轉換上傳的文檔為 Markdown 並儲存
+ * Server Action: converts an uploaded document and redirects to the article page.
  */
 export async function convertDocument(_prev: unknown, formData: FormData) {
 	const file: File | null = formData.get("file") as unknown as File;
@@ -19,31 +13,6 @@ export async function convertDocument(_prev: unknown, formData: FormData) {
 		throw new Error("未提供檔案");
 	}
 
-	// 從檔案名稱獲取檔案類型
-	const fileType = file.name.split(".").pop() || "";
-
-	// 獲取適合的處理器
-	const processor = getDocumentProcessor(fileType);
-
-	// 處理檔案
-	const result = await processor.process(file);
-
-	// 生成儲存 key
-	const key = await generateStorageKey();
-
-	// 儲存處理結果
-	await processor.saveToStorage(result, key);
-
-	// Background: pre-generate glossaries for all languages
-	after(async () => {
-		const xai = createXai({ apiKey: env.XAI_API_KEY });
-		const model = xai("grok-4-1-fast-reasoning");
-		const fullText = result.markdown.join("\n\n");
-		await generateAndCacheAllGlossaries(key, fullText, model);
-	});
-
-	// 更新快取並重定向
-	revalidatePath("/");
-	revalidatePath(`/articles/${key}`);
+	const { key } = await processUploadedFile(file);
 	redirect(`/articles/${key}`);
 }

--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -1,0 +1,49 @@
+import { validateSecret } from "@/lib/auth";
+import { processUploadedFile } from "@/lib/upload";
+import { NextResponse } from "next/server";
+
+// Allow up to 60 seconds for document processing
+export const maxDuration = 60;
+
+/**
+ * POST /api/upload
+ * Accepts a multipart/form-data request with a "file" field (.docx only).
+ * Requires Authorization: Bearer <UPLOAD_SECRET> header.
+ */
+export async function POST(request: Request) {
+	// Validate Bearer token
+	if (!validateSecret(request)) {
+		return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+	}
+
+	// Parse form data
+	let formData: FormData;
+	try {
+		formData = await request.formData();
+	} catch {
+		return NextResponse.json({ error: "Invalid form data" }, { status: 400 });
+	}
+
+	const file = formData.get("file");
+
+	if (!file || !(file instanceof File)) {
+		return NextResponse.json({ error: "Missing file field" }, { status: 400 });
+	}
+
+	// Validate file extension
+	const ext = file.name.split(".").pop()?.toLowerCase();
+	if (ext !== "docx") {
+		return NextResponse.json(
+			{ error: "Only .docx files are supported" },
+			{ status: 400 },
+		);
+	}
+
+	const { key } = await processUploadedFile(file);
+
+	return NextResponse.json({
+		success: true,
+		key,
+		url: `/articles/${key}`,
+	});
+}

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,0 +1,17 @@
+import { timingSafeEqual } from "node:crypto";
+import { env } from "@/lib/env";
+
+/**
+ * Validates the Bearer token in the Authorization header using timing-safe comparison.
+ * Returns true if the token matches UPLOAD_SECRET, false otherwise.
+ */
+export function validateSecret(request: Request): boolean {
+	const authHeader = request.headers.get("authorization");
+	if (!authHeader?.startsWith("Bearer ")) return false;
+	const token = authHeader.slice(7);
+	if (token.length !== env.UPLOAD_SECRET.length) return false;
+	const encoder = new TextEncoder();
+	const a = encoder.encode(token);
+	const b = encoder.encode(env.UPLOAD_SECRET);
+	return timingSafeEqual(new Uint8Array(a), new Uint8Array(b));
+}

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -5,6 +5,7 @@ export const env = createEnv({
 	server: {
 		PERPLEXITY_API_KEY: z.string(),
 		XAI_API_KEY: z.string(),
+		UPLOAD_SECRET: z.string().min(16),
 		BASE_URL: z
 			.string()
 			.url()

--- a/lib/upload.ts
+++ b/lib/upload.ts
@@ -1,0 +1,40 @@
+import { getDocumentProcessor } from "@/lib/document-processor";
+import { generateStorageKey } from "@/lib/document-processor/utils/storage";
+import { env } from "@/lib/env";
+import { generateAndCacheAllGlossaries } from "@/lib/translation/glossary";
+import { createXai } from "@ai-sdk/xai";
+import { revalidatePath } from "next/cache";
+import { after } from "next/server";
+
+/**
+ * Core upload logic: process a file, save it to storage, and kick off background tasks.
+ * Returns the storage key for the processed document.
+ */
+export async function processUploadedFile(file: File): Promise<{ key: string }> {
+	// Get file extension and retrieve the matching processor
+	const fileType = file.name.split(".").pop() || "";
+	const processor = getDocumentProcessor(fileType);
+
+	// Process the file into markdown
+	const result = await processor.process(file);
+
+	// Generate a unique storage key
+	const key = await generateStorageKey();
+
+	// Persist processed content to storage
+	await processor.saveToStorage(result, key);
+
+	// Background: pre-generate glossaries for all languages
+	after(async () => {
+		const xai = createXai({ apiKey: env.XAI_API_KEY });
+		const model = xai("grok-4-1-fast-reasoning");
+		const fullText = result.markdown.join("\n\n");
+		await generateAndCacheAllGlossaries(key, fullText, model);
+	});
+
+	// Invalidate cached paths
+	revalidatePath("/");
+	revalidatePath(`/articles/${key}`);
+
+	return { key };
+}


### PR DESCRIPTION
## Summary
- Extract upload logic from Server Action into reusable `processUploadedFile()` (`lib/upload.ts`)
- Add Bearer token auth with timing-safe comparison (`lib/auth.ts`)
- New `POST /api/upload` route for programmatic uploads (iOS Shortcut integration)
- Existing publish page behavior unchanged

## Test plan
- [ ] `pnpm build` passes
- [ ] `curl -X POST -H "Authorization: Bearer <secret>" -F "file=@test.docx" /api/upload` → 200 + JSON
- [ ] Missing/wrong auth → 401
- [ ] No file or non-.docx → 400
- [ ] Publish page upload still works as before